### PR TITLE
HCK-8640: Incorrect parsing of NamedInstance from connection string

### DIFF
--- a/reverse_engineering/helpers/parseConnectionString.js
+++ b/reverse_engineering/helpers/parseConnectionString.js
@@ -4,22 +4,11 @@ const { URL } = require('url');
 const mssqlPrefix = 'mssql://';
 const sqlserverPrefix = 'jdbc:sqlserver://';
 
-/**
- * Parse MS SQLServer connection URL.
- *
- * Example: mssql://username:password@host:1433/DatabaseName
- *
- * Name instance example: mssql://username:password@host\instance/DatabaseName
- */
+// example: mssql://username:password@host:1433/DatabaseName
 const parseMssqlUrl = ({ url = '' }) => {
-	const [, hostname = ''] = /@([^/]+)/.exec(url) || []; // hostname between @ and first /
-
-	const isNamedInstance = hostname.includes('\\');
-	const replacedUrl = isNamedInstance ? url.replace(hostname, 'host') : url; // replace to make it valid
-	const parsed = new URL(replacedUrl);
-
+	const parsed = new URL(url);
 	return {
-		host: isNamedInstance ? hostname : parsed.hostname,
+		host: parsed.hostname,
 		port: parsed.port ? Number(parsed.port) : null,
 		databaseName: parsed.pathname.slice(1),
 		userName: parsed.username,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8640" title="HCK-8640" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-8640</a>  [MS SQL Server/Synapse] Incorrect parsing of NamedInstance from connection string
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

parse hostname and check if it has '\\' that can be in named instance only