### PR TITLE
HCK-8816: queries optimization

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -107,7 +107,7 @@ module.exports = {
 				await getExternalBrowserUrl(connectionInfo, logger, callback, app);
 			} else {
 				const client = await connect(connectionInfo, logger, () => {}, app);
-				await logDatabaseVersion(client, logger);
+				await logDatabaseVersion({ client, logger });
 			}
 			callback(null);
 		} catch (error) {

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -47,7 +47,7 @@ module.exports = {
 				await this.getExternalBrowserUrl(connectionInfo, logger, callback, app);
 			} else {
 				const client = await this.connect(connectionInfo, logger, () => {}, app);
-				await logDatabaseVersion(client, logger);
+				await logDatabaseVersion({ client, logger });
 			}
 			callback();
 		} catch (error) {
@@ -97,11 +97,11 @@ module.exports = {
 				throw new Error('No database specified');
 			}
 
-			await logDatabaseVersion(client, logger);
+			await logDatabaseVersion({ client, logger });
 
 			const objects = await getObjectsFromDatabase(client);
 			const dbName = client.config.database;
-			const collationData = (await getDatabaseCollationOption(client, dbName, logger)) || [];
+			const collationData = (await getDatabaseCollationOption({ client, dbName, logger })) || [];
 			logger.log('info', { collation: collationData[0] }, 'Database collation');
 			callback(null, objects);
 		} catch (error) {
@@ -132,8 +132,8 @@ module.exports = {
 
 			const reverseEngineeringOptions = getOptionsFromConnectionInfo(collectionsInfo);
 			const [jsonSchemas, relationships] = await Promise.all([
-				await reverseCollectionsToJSON(logger)(client, collections, reverseEngineeringOptions),
-				await getCollectionsRelationships(logger)(client, collections),
+				await reverseCollectionsToJSON({ client, tablesInfo: collections, reverseEngineeringOptions, logger }),
+				await getCollectionsRelationships({ client, logger }),
 			]);
 
 			const jsonSchemasWithDescriptionComments = await getJsonSchemasWithInjectedDescriptionComments({

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -133,7 +133,7 @@ module.exports = {
 			const reverseEngineeringOptions = getOptionsFromConnectionInfo(collectionsInfo);
 			const [jsonSchemas, relationships] = await Promise.all([
 				await reverseCollectionsToJSON({ client, tablesInfo: collections, reverseEngineeringOptions, logger }),
-				await getCollectionsRelationships({ client, logger }),
+				await getCollectionsRelationships({ client, tablesInfo: collections, logger }),
 			]);
 
 			const jsonSchemasWithDescriptionComments = await getJsonSchemasWithInjectedDescriptionComments({

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -24,19 +24,18 @@ module.exports = {
 		const client = clientManager.getClient();
 
 		if (!client) {
-			await clientManager.setClient({
+			return await clientManager.initClient({
 				connectionInfo,
 				logger,
 				sshService: app.require('@hackolade/ssh-service'),
 			});
-			return clientManager.getClient();
 		}
 
 		return client;
 	},
 
-	disconnect(connectionInfo, logger, callback, app) {
-		clientManager.clearClient({ sshService: app.require('@hackolade/ssh-service') });
+	disconnect(connectionInfo, logger, callback) {
+		clientManager.clearClient();
 		callback();
 	},
 
@@ -93,7 +92,7 @@ module.exports = {
 			logInfo('Retrieving databases and tables information', connectionInfo, logger);
 
 			const client = await this.connect(connectionInfo, logger, () => {}, app);
-			if (!client?.config.database) {
+			if (!client.config.database) {
 				throw new Error('No database specified');
 			}
 

--- a/reverse_engineering/clientManager.js
+++ b/reverse_engineering/clientManager.js
@@ -33,7 +33,7 @@ class ClientManager {
 		}
 
 		try {
-			this.#client = await getConnectionClient(connectionParams, logger);
+			this.#client = await getConnectionClient({ connectionInfo: connectionParams, logger });
 		} catch (error) {
 			const encryptConnection =
 				connectionParams.encryptConnection === undefined || Boolean(connectionParams.encryptConnection);

--- a/reverse_engineering/databaseService/databaseService.js
+++ b/reverse_engineering/databaseService/databaseService.js
@@ -232,23 +232,26 @@ const getTableInfo = async ({ client, dbName, tableName, tableSchema, logger }) 
 		},
 		logger,
 	});
+
 	const objectId = `${tableSchema}.${tableName}`;
 
-	const result = await currentDbConnectionClient.query(`
-	SELECT c.*,
-		ic.SEED_VALUE,
-		ic.INCREMENT_VALUE,
-		COLUMNPROPERTY(OBJECT_ID(${objectId}), c.column_name, 'IsSparse') AS IS_SPARSE,
-		COLUMNPROPERTY(OBJECT_ID(${objectId}), c.column_name, 'IsIdentity') AS IS_IDENTITY,
-		o.type AS TABLE_TYPE
-	FROM INFORMATION_SCHEMA.COLUMNS AS c
-	LEFT JOIN sys.identity_columns ic ON ic.object_id=OBJECT_ID(${objectId})
-	LEFT JOIN sys.objects o ON o.object_id=OBJECT_ID(${objectId})
-	WHERE c.table_name = ${tableName}
-		AND c.table_schema = ${tableSchema};
-	`);
-
-	return mapResponse(result);
+	return mapResponse(
+		await currentDbConnectionClient.query`
+			SELECT c.*,
+				ic.SEED_VALUE,
+				ic.INCREMENT_VALUE,
+				COLUMNPROPERTY(OBJECT_ID(${objectId}), c.column_name, 'IsSparse') AS IS_SPARSE,
+				COLUMNPROPERTY(OBJECT_ID(${objectId}), c.column_name, 'IsIdentity') AS IS_IDENTITY,
+				o.type AS TABLE_TYPE
+			FROM INFORMATION_SCHEMA.COLUMNS AS c
+			LEFT JOIN sys.identity_columns ic
+				ON ic.object_id=OBJECT_ID(${objectId})
+			LEFT JOIN sys.objects o
+				ON o.object_id=OBJECT_ID(${objectId})
+			WHERE c.table_name = ${tableName}
+				AND c.table_schema = ${tableSchema};
+	`,
+	);
 };
 
 const getTableSystemTime = async ({ client, dbName, tableName, tableSchema, logger }) => {
@@ -262,18 +265,20 @@ const getTableSystemTime = async ({ client, dbName, tableName, tableSchema, logg
 		},
 		logger,
 	});
+
 	const objectId = `${tableSchema}.${tableName}`;
+
 	return mapResponse(
-		await currentDbConnectionClient.query(`
-		SELECT
-			col_name(p.object_id, p.start_column_id) as startColumn,
-			COLUMNPROPERTY(p.object_id, col_name(p.object_id, p.start_column_id), 'IsHidden') as startColumnIsHidden,
-			col_name(p.object_id, p.end_column_id) as endColumn,
-			COLUMNPROPERTY(p.object_id, col_name(p.object_id, p.start_column_id), 'IsHidden') as endColumnIsHidden
-		FROM sys.periods p
-		WHERE p.object_id = OBJECT_ID(${objectId})
-			AND p.period_type = 1;
-		;`),
+		await currentDbConnectionClient.query`
+			SELECT
+				col_name(p.object_id, p.start_column_id) AS startColumn,
+				COLUMNPROPERTY(p.object_id, col_name(p.object_id, p.start_column_id), 'IsHidden') AS startColumnIsHidden,
+				col_name(p.object_id, p.end_column_id) AS endColumn,
+				COLUMNPROPERTY(p.object_id, col_name(p.object_id, p.start_column_id), 'IsHidden') AS endColumnIsHidden
+			FROM sys.periods p
+			WHERE p.object_id = OBJECT_ID(${objectId})
+				AND p.period_type = 1;
+	`,
 	);
 };
 
@@ -348,37 +353,37 @@ const getTableForeignKeys = async ({ client, tablesInfo, dbName, logger }) => {
 	const whereClauseParts = flatMap(
 		Object.entries(tablesInfo).map(([schemaName, tableNames]) =>
 			tableNames.map(
-				tableName => `(${table1Alias}.name = '${tableName}' AND ${schemaAlias}.name = ${schemaName})`,
+				tableName => `(${table1Alias}.name = '${tableName}' AND ${schemaAlias}.name = '${schemaName}')`,
 			),
 		),
 	);
 
 	return mapResponse(
 		await currentDbConnectionClient.query(`
-		SELECT obj.name AS FK_NAME,
-			${schemaAlias}.name AS [schema_name],
-			${table1Alias}.name AS [table],
-			col1.name AS [column],
-			tab2.name AS [referenced_table],
-			col2.name AS [referenced_column],
-			fk.delete_referential_action_desc AS on_delete,
-			fk.update_referential_action_desc AS on_update
-		FROM sys.foreign_key_columns fkc
-		INNER JOIN sys.objects obj
-			ON obj.object_id = fkc.constraint_object_id
-		INNER JOIN sys.tables ${table1Alias}
-			ON ${table1Alias}.object_id = fkc.parent_object_id
-		INNER JOIN sys.schemas ${schemaAlias}
-			ON ${table1Alias}.schema_id = ${schemaAlias}.schema_id
-		INNER JOIN sys.columns col1
-			ON col1.column_id = parent_column_id AND col1.object_id = ${table1Alias}.object_id
-		INNER JOIN sys.tables tab2
-			ON tab2.object_id = fkc.referenced_object_id
-		INNER JOIN sys.columns col2
-			ON col2.column_id = referenced_column_id AND col2.object_id = tab2.object_id
-		INNER JOIN sys.foreign_keys fk
-			ON fk.object_id = obj.object_id
-		WHERE ${whereClauseParts.join(' OR ')}
+			SELECT obj.name AS FK_NAME,
+				${schemaAlias}.name AS [schema_name],
+				${table1Alias}.name AS [table],
+				col1.name AS [column],
+				tab2.name AS [referenced_table],
+				col2.name AS [referenced_column],
+				fk.delete_referential_action_desc AS on_delete,
+				fk.update_referential_action_desc AS on_update
+			FROM sys.foreign_key_columns fkc
+			INNER JOIN sys.objects obj
+				ON obj.object_id = fkc.constraint_object_id
+			INNER JOIN sys.tables ${table1Alias}
+				ON ${table1Alias}.object_id = fkc.parent_object_id
+			INNER JOIN sys.schemas ${schemaAlias}
+				ON ${table1Alias}.schema_id = ${schemaAlias}.schema_id
+			INNER JOIN sys.columns col1
+				ON col1.column_id = parent_column_id AND col1.object_id = ${table1Alias}.object_id
+			INNER JOIN sys.tables tab2
+				ON tab2.object_id = fkc.referenced_object_id
+			INNER JOIN sys.columns col2
+				ON col2.column_id = referenced_column_id AND col2.object_id = tab2.object_id
+			INNER JOIN sys.foreign_keys fk
+				ON fk.object_id = obj.object_id
+			WHERE ${whereClauseParts.join(' OR ')}
 		`),
 	);
 };
@@ -405,27 +410,27 @@ const getDatabaseIndexes = async ({ client, dbName, tablesInfo, logger }) => {
 
 	return mapResponse(
 		await currentDbConnectionClient.query(`
-		SELECT
-			TableName = t.name,
-			IndexName = ind.name,
-			ic.is_descending_key,
-			ic.is_included_column,
-			COL_NAME(t.object_id, ic.column_id) AS columnName,
-			OBJECT_SCHEMA_NAME(t.object_id) AS schemaName,
-			p.data_compression_desc AS dataCompression,
-			ind.*
-		FROM sys.indexes ind
-		LEFT JOIN sys.tables t
-			ON ind.object_id = t.object_id
-		INNER JOIN sys.index_columns ic
-			ON ind.object_id = ic.object_id AND ind.index_id = ic.index_id
-		INNER JOIN sys.partitions p
-			ON p.object_id = t.object_id AND ind.index_id = p.index_id
-		WHERE
-			ind.is_primary_key = 0
-			AND ind.is_unique_constraint = 0
-			AND t.is_ms_shipped = 0
-			AND ${whereClauseParts.join(' OR ')}
+			SELECT
+				TableName = t.name,
+				IndexName = ind.name,
+				ic.is_descending_key,
+				ic.is_included_column,
+				COL_NAME(t.object_id, ic.column_id) AS columnName,
+				OBJECT_SCHEMA_NAME(t.object_id) AS schemaName,
+				p.data_compression_desc AS dataCompression,
+				ind.*
+			FROM sys.indexes ind
+			LEFT JOIN sys.tables t
+				ON ind.object_id = t.object_id
+			INNER JOIN sys.index_columns ic
+				ON ind.object_id = ic.object_id AND ind.index_id = ic.index_id
+			INNER JOIN sys.partitions p
+				ON p.object_id = t.object_id AND ind.index_id = p.index_id
+			WHERE
+				ind.is_primary_key = 0
+				AND ind.is_unique_constraint = 0
+				AND t.is_ms_shipped = 0
+				AND ${whereClauseParts.join(' OR ')}
 		`),
 	);
 };
@@ -609,19 +614,19 @@ const getTableColumnsDescription = async ({ client, dbName, tableName, schemaNam
 	logger.log('info', { message: `Get '${tableName}' table columns description.` }, 'Reverse Engineering');
 
 	return mapResponse(
-		currentDbConnectionClient.query(`
-		SELECT
-			st.name [Table],
-			sc.name [Column],
-			sep.value [Description]
-		FROM sys.tables st
-		INNER JOIN sys.columns sc ON st.object_id = sc.object_id
-		LEFT JOIN sys.extended_properties sep ON st.object_id = sep.major_id
-			AND sc.column_id = sep.minor_id
-			AND sep.name = 'MS_Description'
-		WHERE st.name = ${tableName}
-		AND st.schema_id=SCHEMA_ID(${schemaName})
-	`),
+		currentDbConnectionClient.query`
+			SELECT
+				st.name [Table],
+				sc.name [Column],
+				sep.value [Description]
+			FROM sys.tables st
+			INNER JOIN sys.columns sc ON st.object_id = sc.object_id
+			LEFT JOIN sys.extended_properties sep ON st.object_id = sep.major_id
+				AND sc.column_id = sep.minor_id
+				AND sep.name = 'MS_Description'
+			WHERE st.name = ${tableName}
+			AND st.schema_id=SCHEMA_ID(${schemaName})
+	`,
 	);
 };
 
@@ -701,40 +706,40 @@ const getViewTableInfo = async ({ client, dbName, viewName, schemaName, logger }
 
 	const objectId = `${schemaName}.${viewName}`;
 	return mapResponse(
-		currentDbConnectionClient.query(`
-		SELECT
-			ViewName = O.name,
-			ColumnName = A.name,
-			ReferencedSchemaName = SCHEMA_NAME(X.schema_id),
-			ReferencedTableName = X.name,
-			ReferencedColumnName = C.name,
-			T.is_selected,
-			T.is_updated,
-			T.is_select_all,
-			ColumnType = M.name,
-			M.max_length,
-			M.precision,
-			M.scale
-		FROM sys.sql_dependencies AS T
-		INNER JOIN sys.objects AS O
-			ON T.object_id = O.object_id
-		INNER JOIN sys.objects AS X
-			ON T.referenced_major_id = X.object_id
-		INNER JOIN sys.columns AS C
-			ON C.object_id = X.object_id AND C.column_id = T.referenced_minor_id
-		INNER JOIN sys.types AS M
-			ON M.system_type_id = C.system_type_id AND M.user_type_id = C.user_type_id
-		INNER JOIN sys.columns AS A
-			ON A.object_id = OBJECT_ID(${objectId}) AND T.referenced_minor_id = A.column_id
-		WHERE
-			O.type = 'V'
-			AND O.name = ${viewName}
-			AND O.schema_id=SCHEMA_ID(${schemaName})
-		ORDER BY
-			O.name,
-			X.name,
-			C.name
-	`),
+		currentDbConnectionClient.query`
+			SELECT
+				ViewName = O.name,
+				ColumnName = A.name,
+				ReferencedSchemaName = SCHEMA_NAME(X.schema_id),
+				ReferencedTableName = X.name,
+				ReferencedColumnName = C.name,
+				T.is_selected,
+				T.is_updated,
+				T.is_select_all,
+				ColumnType = M.name,
+				M.max_length,
+				M.precision,
+				M.scale
+			FROM sys.sql_dependencies AS T
+			INNER JOIN sys.objects AS O
+				ON T.object_id = O.object_id
+			INNER JOIN sys.objects AS X
+				ON T.referenced_major_id = X.object_id
+			INNER JOIN sys.columns AS C
+				ON C.object_id = X.object_id AND C.column_id = T.referenced_minor_id
+			INNER JOIN sys.types AS M
+				ON M.system_type_id = C.system_type_id AND M.user_type_id = C.user_type_id
+			INNER JOIN sys.columns AS A
+				ON A.object_id = OBJECT_ID(${objectId}) AND T.referenced_minor_id = A.column_id
+			WHERE
+				O.type = 'V'
+				AND O.name = ${viewName}
+				AND O.schema_id=SCHEMA_ID(${schemaName})
+			ORDER BY
+				O.name,
+				X.name,
+				C.name
+		`,
 	);
 };
 
@@ -808,39 +813,39 @@ const getTableKeyConstraints = async ({ client, dbName, tableName, schemaName, l
 
 	const objectId = `${schemaName}.${tableName}`;
 	return mapResponse(
-		await currentDbConnectionClient.query(`
-		SELECT
-			TC.TABLE_NAME AS tableName,
-			TC.Constraint_Name AS constraintName,
-			CC.Column_Name AS columnName,
-			TC.constraint_type AS constraintType,
-			ind.type_desc AS typeDesc,
-			p.data_compression_desc AS dataCompression,
-			ds.name AS dataSpaceName,
-			st.no_recompute AS statisticNoRecompute,
-			st.is_incremental AS statisticsIncremental,
-			ic.is_descending_key AS isDescending,
-			ind.*
-		FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC
-		INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE CC
-			ON TC.Constraint_Name = CC.Constraint_Name
-				AND TC.TABLE_NAME=${tableName}
-			    AND TC.TABLE_SCHEMA=${schemaName}
-		INNER JOIN sys.indexes ind
-			ON ind.name = TC.CONSTRAINT_NAME
-		INNER JOIN sys.stats st
-			ON st.name = TC.CONSTRAINT_NAME
-		LEFT JOIN sys.data_spaces ds
-			ON ds.data_space_id = ind.data_space_id
-		INNER JOIN sys.index_columns ic
-			ON ic.object_id = OBJECT_ID(${objectId})
-				AND ind.index_id=ic.index_id
-				AND ic.column_id=COLUMNPROPERTY(OBJECT_ID(${objectId}), CC.column_name, 'ColumnId')
-		INNER JOIN sys.partitions p
-			ON p.object_id = OBJECT_ID(${objectId})
-			    AND p.index_id = ind.index_id
-		ORDER BY TC.Constraint_Name
-	`),
+		await currentDbConnectionClient.query`
+			SELECT
+				TC.TABLE_NAME AS tableName,
+				TC.Constraint_Name AS constraintName,
+				CC.Column_Name AS columnName,
+				TC.constraint_type AS constraintType,
+				ind.type_desc AS typeDesc,
+				p.data_compression_desc AS dataCompression,
+				ds.name AS dataSpaceName,
+				st.no_recompute AS statisticNoRecompute,
+				st.is_incremental AS statisticsIncremental,
+				ic.is_descending_key AS isDescending,
+				ind.*
+			FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC
+			INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE CC
+				ON TC.Constraint_Name = CC.Constraint_Name
+					AND TC.TABLE_NAME=${tableName}
+					AND TC.TABLE_SCHEMA=${schemaName}
+			INNER JOIN sys.indexes ind
+				ON ind.name = TC.CONSTRAINT_NAME
+			INNER JOIN sys.stats st
+				ON st.name = TC.CONSTRAINT_NAME
+			LEFT JOIN sys.data_spaces ds
+				ON ds.data_space_id = ind.data_space_id
+			INNER JOIN sys.index_columns ic
+				ON ic.object_id = OBJECT_ID(${objectId})
+					AND ind.index_id=ic.index_id
+					AND ic.column_id=COLUMNPROPERTY(OBJECT_ID(${objectId}), CC.column_name, 'ColumnId')
+			INNER JOIN sys.partitions p
+				ON p.object_id = OBJECT_ID(${objectId})
+					AND p.index_id = ind.index_id
+			ORDER BY TC.Constraint_Name
+		`,
 	);
 };
 
@@ -860,10 +865,10 @@ const getTableMaskedColumns = async ({ client, dbName, tableName, schemaName, lo
 
 	const objectId = `${schemaName}.${tableName}`;
 	return mapResponse(
-		await currentDbConnectionClient.query(`
-		SELECT name, masking_function FROM sys.masked_columns
-		WHERE object_id=OBJECT_ID(${objectId})
-	`),
+		await currentDbConnectionClient.query`
+			SELECT name, masking_function FROM sys.masked_columns
+			WHERE object_id=OBJECT_ID(${objectId})
+		`,
 	);
 };
 
@@ -908,21 +913,21 @@ const getTableDefaultConstraintNames = async ({ client, dbName, tableName, schem
 	logger.log('info', { message: `Get '${tableName}' table default constraint names.` }, 'Reverse Engineering');
 
 	return mapResponse(
-		await currentDbConnectionClient.query(`
-	SELECT
-		ac.name AS columnName,
-		dc.name
-	FROM sys.all_columns AS ac
-	INNER JOIN sys.tables
-		ON ac.object_id = tables.object_id
-	INNER JOIN sys.schemas
-		ON tables.schema_id = schemas.schema_id
-	INNER JOIN sys.default_constraints AS dc
-		ON ac.default_object_id = dc.object_id
-	WHERE
-		schemas.name = ${schemaName}
-		AND tables.name = ${tableName}
-	`),
+		await currentDbConnectionClient.query`
+			SELECT
+				ac.name AS columnName,
+				dc.name
+			FROM sys.all_columns AS ac
+			INNER JOIN sys.tables
+				ON ac.object_id = tables.object_id
+			INNER JOIN sys.schemas
+				ON tables.schema_id = schemas.schema_id
+			INNER JOIN sys.default_constraints AS dc
+				ON ac.default_object_id = dc.object_id
+			WHERE
+				schemas.name = ${schemaName}
+				AND tables.name = ${tableName}
+		`,
 	);
 };
 

--- a/reverse_engineering/databaseService/databaseService.js
+++ b/reverse_engineering/databaseService/databaseService.js
@@ -581,7 +581,7 @@ const getFullTextIndexes = async ({ client, dbName, allUniqueSchemasAndTables, l
 	);
 };
 
-const getViewsIndexes = async ({ client, dbName, allUniqueSchemasAndTables, logger }) => {
+const getViewsIndexes = async ({ client, dbName, logger }) => {
 	const currentDbConnectionClient = await getClient({
 		client,
 		dbName,
@@ -596,7 +596,6 @@ const getViewsIndexes = async ({ client, dbName, allUniqueSchemasAndTables, logg
 	logger.log('info', { message: `Get '${dbName}' database views indexes.` }, 'Reverse Engineering');
 
 	const tableAlias = 'ind';
-	const whereClauseParts = getWhereClauseForUniqueSchemasAndTables({ tableAlias, allUniqueSchemasAndTables });
 
 	return mapResponse(
 		await currentDbConnectionClient.query(`
@@ -620,7 +619,6 @@ const getViewsIndexes = async ({ client, dbName, allUniqueSchemasAndTables, logg
 			${tableAlias}.is_primary_key = 0
 			AND ${tableAlias}.is_unique_constraint = 0
 			AND t.is_ms_shipped = 0
-			AND ${whereClauseParts}
 		`),
 	);
 };

--- a/reverse_engineering/helpers/commentsHelper.js
+++ b/reverse_engineering/helpers/commentsHelper.js
@@ -67,8 +67,8 @@ const getJsonSchemasWithInjectedDescriptionComments = async ({ client, dbName, j
 
 	const descriptionComments = (
 		await Promise.all(
-			[...schemas, ...schemasWithViews, ...schemasWithTables, ...entities].map(commentParams =>
-				getDescriptionComments(client, dbName, commentParams, logger),
+			[...schemas, ...schemasWithViews, ...schemasWithTables, ...entities].map(({ schema, entity }) =>
+				getDescriptionComments({ client, dbName, schema, entity, logger }),
 			),
 		)
 	).flat();

--- a/reverse_engineering/reverseEngineeringService/helpers/changeViewPropertiesToReferences.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/changeViewPropertiesToReferences.js
@@ -3,7 +3,7 @@ const getColumnInfoByName = (columnsInfo, columnName, propertyName) => {
 	return relatedColumn[propertyName];
 };
 
-const changeViewPropertiesToReferences = (jsonSchema, viewInfo, viewColumnRelations) => {
+const changeViewPropertiesToReferences = ({ jsonSchema, viewInfo, viewColumnRelations }) => {
 	return viewColumnRelations.reduce((jsonSchemaAcc, column) => {
 		const columnName = column['name'];
 		const referenceTable =

--- a/reverse_engineering/reverseEngineeringService/helpers/containsJson.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/containsJson.js
@@ -1,15 +1,10 @@
-const containsJson = tableInfo => {
-	return tableInfo.some(item => {
+const containsJson = ({ tableInfo }) =>
+	tableInfo.some(item => {
 		if (item['DATA_TYPE'] !== 'nvarchar') {
 			return false;
 		}
 
-		if (item['CHARACTER_MAXIMUM_LENGTH'] >= 0 && item['CHARACTER_MAXIMUM_LENGTH'] < 4000) {
-			return false;
-		}
-
-		return true;
+		return !(item['CHARACTER_MAXIMUM_LENGTH'] >= 0 && item['CHARACTER_MAXIMUM_LENGTH'] < 4000);
 	});
-};
 
 module.exports = containsJson;

--- a/reverse_engineering/reverseEngineeringService/helpers/defineFieldsCompositeKeyConstraints.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/defineFieldsCompositeKeyConstraints.js
@@ -4,8 +4,8 @@ const getKeyConstraintsCompositionStatuses = require('./getKeyConstraintsComposi
 const UNIQUE = 'UNIQUE';
 const PRIMARY_KEY = 'PRIMARY KEY';
 
-const reverseCompositeKeys = keyConstraintsInfo => {
-	const keyCompositionStatuses = getKeyConstraintsCompositionStatuses(keyConstraintsInfo);
+const reverseCompositeKeys = ({ keyConstraintsInfo }) => {
+	const keyCompositionStatuses = getKeyConstraintsCompositionStatuses({ keyConstraintsInfo });
 	return keyConstraintsInfo.reduce((reversedKeys, keyConstraintInfo) => {
 		const { columnName, constraintName, constraintType, isDescending } = keyConstraintInfo;
 		const compositionStatus = keyCompositionStatuses[constraintName];
@@ -52,8 +52,8 @@ const reverseCompositeKeys = keyConstraintsInfo => {
 	}, {});
 };
 
-const defineFieldsCompositeKeyConstraints = keyConstraintsInfo => {
-	const reversedKeyConstraints = reverseCompositeKeys(keyConstraintsInfo);
+const defineFieldsCompositeKeyConstraints = ({ keyConstraintsInfo }) => {
+	const reversedKeyConstraints = reverseCompositeKeys({ keyConstraintsInfo });
 	return Object.values(reversedKeyConstraints).reduce(
 		(keysAcc, keyConstraintInfo) => {
 			const { _type, order, ...necessaryInfo } = keyConstraintInfo;

--- a/reverse_engineering/reverseEngineeringService/helpers/defineFieldsKeyConstraints.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/defineFieldsKeyConstraints.js
@@ -32,7 +32,7 @@ const handleKey = (field, keyConstraintInfo) => {
 };
 
 const defineFieldsKeyConstraints = keyConstraintsInfo => jsonSchema => {
-	const keyCompositionStatuses = getKeyConstraintsCompositionStatuses(keyConstraintsInfo);
+	const keyCompositionStatuses = getKeyConstraintsCompositionStatuses({ keyConstraintsInfo });
 	return keyConstraintsInfo.reduce((jsonSchemaAcc, keyConstraintInfo) => {
 		const { columnName, constraintName } = keyConstraintInfo;
 		const currentField = jsonSchemaAcc.properties[columnName];

--- a/reverse_engineering/reverseEngineeringService/helpers/getKeyConstraintsCompositionStatuses.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/getKeyConstraintsCompositionStatuses.js
@@ -1,4 +1,4 @@
-const getKeyConstraintsCompositionStatuses = keyConstraintsInfo => {
+const getKeyConstraintsCompositionStatuses = ({ keyConstraintsInfo }) => {
 	const keyConstraintsColumns = keyConstraintsInfo.reduce((constraintsColumns, keyConstraintInfo) => {
 		const { constraintName, columnName } = keyConstraintInfo;
 		const currentConstraintColumns = constraintsColumns[constraintName];
@@ -18,7 +18,7 @@ const getKeyConstraintsCompositionStatuses = keyConstraintsInfo => {
 	return Object.entries(keyConstraintsColumns).reduce(
 		(statuses, [name, columns]) => ({
 			...statuses,
-			[name]: Array.from(new Set(columns)).length > 1 ? true : false,
+			[name]: Array.from(new Set(columns)).length > 1,
 		}),
 		{},
 	);

--- a/reverse_engineering/reverseEngineeringService/helpers/getPeriodForSystemTime.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/getPeriodForSystemTime.js
@@ -1,10 +1,12 @@
 const { getTableSystemTime } = require('../../databaseService/databaseService');
 
-const getPeriodForSystemTime = async (dbConnectionClient, dbName, tableName, schemaName, logger) => {
-	const tableSystemTime = await getTableSystemTime(dbConnectionClient, dbName, tableName, schemaName, logger);
+const getPeriodForSystemTime = async ({ client, dbName, tableName, schemaName, logger }) => {
+	const tableSystemTime = await getTableSystemTime({ client, dbName, tableName, tableSchema: schemaName, logger });
+
 	if (!tableSystemTime[0]) {
 		return;
 	}
+
 	const periodForSystemTime = tableSystemTime[0];
 	return [
 		{

--- a/reverse_engineering/reverseEngineeringService/helpers/reorderTableRows.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/reorderTableRows.js
@@ -1,4 +1,4 @@
-const reorderTableRows = (tableRows, isFieldOrderAlphabetic) => {
+const reorderTableRows = ({ tableRows, isFieldOrderAlphabetic }) => {
 	if (!isFieldOrderAlphabetic) {
 		return tableRows;
 	}

--- a/reverse_engineering/reverseEngineeringService/helpers/reverseTableIndexes.js
+++ b/reverse_engineering/reverseEngineeringService/helpers/reverseTableIndexes.js
@@ -153,7 +153,7 @@ const addKeys = (indexData, index) => {
 	}
 };
 
-const reverseTableIndexes = tableIndexes =>
+const reverseTableIndexes = ({ tableIndexes }) =>
 	Object.values(
 		tableIndexes.reduce((indexList, index) => {
 			let existedIndex = indexList[index.IndexName];

--- a/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
+++ b/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
@@ -431,24 +431,31 @@ function isViewTable({ tableInfo }) {
 	return tableType && tableType.trim() === 'V';
 }
 
-const createJsonSchema = async ({ tableInfo, tableRows, fieldsKeyConstraints, schemaName, tableName, ...context }) => {
-	const { client, dbName, logger } = context;
-
+const createJsonSchema = async ({
+	tableInfo,
+	tableRows,
+	fieldsKeyConstraints,
+	schemaName,
+	tableName,
+	xmlSchemaCollections,
+	client,
+	dbName,
+	logger,
+}) => {
+	const commonContext = { client, dbName, tableName, schemaName, logger };
 	return pipe(
 		transformDatabaseTableInfoToJSON(tableInfo),
 		defineRequiredFields,
-		defineFieldsDescription(await getTableColumnsDescription({ client, dbName, tableName, schemaName, logger })),
+		defineFieldsDescription(await getTableColumnsDescription(commonContext)),
 		defineFieldsKeyConstraints(fieldsKeyConstraints),
-		defineMaskedColumns(await getTableMaskedColumns({ client, dbName, tableName, schemaName, logger })),
+		defineMaskedColumns(await getTableMaskedColumns(commonContext)),
 		defineJSONTypes(tableRows),
 		defineXmlFieldsCollections(
-			context.xmlSchemaCollections.filter(
+			xmlSchemaCollections.filter(
 				collection => collection.tableName === tableName && collection.schemaName === schemaName,
 			),
 		),
-		defineFieldsDefaultConstraintNames(
-			await getTableDefaultConstraintNames({ client, dbName, tableName, schemaName, logger }),
-		),
+		defineFieldsDefaultConstraintNames(await getTableDefaultConstraintNames(commonContext)),
 	)({ required: [], properties: {} });
 };
 

--- a/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
+++ b/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
@@ -416,6 +416,7 @@ const processTable = async ({ schemaName, rawTableName, ...context }) => {
 		reorderedTableRows,
 		periodForSystemTime,
 		tableInfo,
+		fieldsKeyConstraints,
 	});
 
 	if (isView) {
@@ -467,6 +468,8 @@ const getAllUniqueSchemasAndTables = ({ tablesInfo }) =>
 	);
 
 const createTableResult = ({
+	dbName,
+	databaseUDT,
 	tableName,
 	schemaName,
 	jsonSchema,
@@ -474,11 +477,14 @@ const createTableResult = ({
 	reorderedTableRows,
 	periodForSystemTime,
 	tableInfo,
-	...context
+	fieldsKeyConstraints,
+	databaseIndexes,
+	fullTextIndexes,
+	spatialIndexes,
+	databaseCheckConstraints,
+	databaseMemoryOptimizedTables,
 }) => {
-	const { databaseIndexes, databaseMemoryOptimizedTables, databaseCheckConstraints } = context;
-
-	const tableIndexes = [...databaseIndexes, ...context.fullTextIndexes, ...context.spatialIndexes].filter(
+	const tableIndexes = [...databaseIndexes, ...fullTextIndexes, ...spatialIndexes].filter(
 		index => index.TableName === tableName && index.schemaName === schemaName,
 	);
 
@@ -492,14 +498,14 @@ const createTableResult = ({
 			chkConstr: reverseTableCheckConstraints(tableCheckConstraints),
 			periodForSystemTime,
 			...getMemoryOptimizedOptions(databaseMemoryOptimizedTables.find(item => item.name === tableName)),
-			...defineFieldsCompositeKeyConstraints([]),
+			...defineFieldsCompositeKeyConstraints({ keyConstraintsInfo: fieldsKeyConstraints }),
 		},
 		standardDoc,
 		documentTemplate: standardDoc,
 		collectionDocs: reorderedTableRows,
 		documents: cleanDocuments(reorderedTableRows),
-		bucketInfo: { databaseName: context.dbName },
-		modelDefinitions: { definitions: getUserDefinedTypes(tableInfo, context.databaseUDT) },
+		bucketInfo: { databaseName: dbName },
+		modelDefinitions: { definitions: getUserDefinedTypes(tableInfo, databaseUDT) },
 		emptyBucket: false,
 		validation: { jsonSchema },
 		views: [],

--- a/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
+++ b/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
@@ -302,7 +302,7 @@ const fetchDatabaseMetadata = async ({ client, dbName, tablesInfo, logger }) => 
 		getDatabaseCheckConstraints({ client, dbName, logger }),
 		getDatabaseXmlSchemaCollection({ client, dbName, logger }),
 		getDatabaseUserDefinedTypes({ client, dbName, logger }),
-		getViewsIndexes({ client, dbName, allUniqueSchemasAndTables, logger }),
+		getViewsIndexes({ client, dbName, logger }),
 		getFullTextIndexes({ client, dbName, allUniqueSchemasAndTables, logger }),
 		getSpatialIndexes({ client, dbName, allUniqueSchemasAndTables, logger }),
 	]);

--- a/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
+++ b/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
@@ -59,11 +59,11 @@ const mergeCollectionsWithViews = ({ jsonSchemas }) => {
 	return [...collectionSchemas, ...combinedViewSchemas];
 };
 
-const getCollectionsRelationships = async ({ client, logger }) => {
+const getCollectionsRelationships = async ({ client, tablesInfo, logger }) => {
 	const dbName = client.config.database;
 	logger.log('info', { message: `Fetching tables relationships.` }, 'Reverse Engineering');
 	logger.progress({ message: 'Fetching tables relationships', containerName: dbName, entityName: '' });
-	const tableForeignKeys = await getTableForeignKeys({ client, dbName, logger });
+	const tableForeignKeys = await getTableForeignKeys({ client, dbName, tablesInfo, logger });
 
 	return reverseTableForeignKeys(tableForeignKeys, dbName);
 };
@@ -283,7 +283,7 @@ const addTotalBucketCountToDatabaseIndexes = ({ databaseIndexes, indexesBucketCo
 	});
 };
 
-const fetchDatabaseMetadata = async ({ client, dbName, logger }) => {
+const fetchDatabaseMetadata = async ({ client, dbName, tablesInfo, logger }) => {
 	const [
 		rawDatabaseIndexes,
 		databaseMemoryOptimizedTables,
@@ -294,7 +294,7 @@ const fetchDatabaseMetadata = async ({ client, dbName, logger }) => {
 		fullTextIndexes,
 		spatialIndexes,
 	] = await Promise.all([
-		getDatabaseIndexes({ client, dbName, logger }),
+		getDatabaseIndexes({ client, dbName, tablesInfo, logger }),
 		getDatabaseMemoryOptimizedTables({ client, dbName, logger }),
 		getDatabaseCheckConstraints({ client, dbName, logger }),
 		getDatabaseXmlSchemaCollection({ client, dbName, logger }),
@@ -522,7 +522,7 @@ const reverseCollectionsToJSON = async ({ client, tablesInfo, reverseEngineering
 		viewsIndexes,
 		fullTextIndexes,
 		spatialIndexes,
-	} = await fetchDatabaseMetadata({ client, dbName, logger });
+	} = await fetchDatabaseMetadata({ client, dbName, tablesInfo, logger });
 
 	return processSchemas({
 		tablesInfo,

--- a/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
+++ b/reverse_engineering/reverseEngineeringService/reverseEngineeringService.js
@@ -299,8 +299,8 @@ const fetchDatabaseMetadata = async ({ client, dbName, tablesInfo, logger }) => 
 	] = await Promise.all([
 		getDatabaseIndexes({ client, dbName, tablesInfo, logger }),
 		getDatabaseMemoryOptimizedTables({ client, dbName, logger }),
-		getDatabaseCheckConstraints({ client, dbName, logger }),
-		getDatabaseXmlSchemaCollection({ client, dbName, logger }),
+		getDatabaseCheckConstraints({ client, dbName, allUniqueSchemasAndTables, logger }),
+		getDatabaseXmlSchemaCollection({ client, dbName, allUniqueSchemasAndTables, logger }),
 		getDatabaseUserDefinedTypes({ client, dbName, logger }),
 		getViewsIndexes({ client, dbName, logger }),
 		getFullTextIndexes({ client, dbName, allUniqueSchemasAndTables, logger }),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8816" title="HCK-8816" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8816</a>  [SQLServer] RE from instance: Filter queries based on user selection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* the following queries have been optimized and now include the `WHERE` clause specifying the previously selected schemas and tables (expand `databaseService.js` diff to investigate the highlighted part):
  * [getTableForeignKeys](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R386)
  * [getDatabaseIndexes](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R425) (exception: adjusted the LEFT JOIN with schemas/table names)
  * [getSpatialIndexes](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R513)
  * [getFullTextIndexes](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R579)
  * [getDatabaseMemoryOptimizedTables](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R684) (exception: querying only the `is_memory_optimized` tables)
  * [getDatabaseCheckConstraints](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R721)
  * [getTableKeyConstraints](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R880-R881)
  * [getDatabaseXmlSchemaCollection](https://github.com/hackolade/SQLServer/pull/120/files#diff-e3f5b65762cbb648a5c7ae82aed301f14bae3895cbe322edc76af826d7c8e623R942)
* refactored `connectionState` into a `ClientManager` class
* resolved legacy sonarlint remarks

## Comparison metrics between `WHERE` and `WITH` approaches
WHERE - https://www.brentozar.com/pastetheplan/?id=S1HElHm7yx
```
SELECT ...
Cached plan size	312 KB
Estimated Operator Cost	0 (0%)
Estimated Subtree Cost	0.110886
Estimated Number of Rows	7.83363
```
---
WITH - https://www.brentozar.com/pastetheplan/?id=Hkon1BX7Jx
```
WITH ...
Cached plan size	288 KB
Estimated Operator Cost	0 (0%)
Estimated Subtree Cost	0.155635
Estimated Number of Rows	7.83363
```
