### PR TITLE
HCK-9128: Handle indexes without name in SQL Server

### DIFF
--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -17,8 +17,7 @@ module.exports = {
 		'CREATE${unique}${clustered}${columnstore} INDEX ${name}\n' +
 		'\tON ${table}${keys}${include}${expression}${relational_index_option}${terminator}\n',
 
-	fullTextIndex:
-		'CREATE FULLTEXT INDEX ON ${table} (\n\t${keys}\n)\nKEY INDEX ${indexName}\n${catalog}${options}${terminator}\n',
+	fullTextIndex: 'CREATE FULLTEXT INDEX ON ${table}\nKEY INDEX ${indexName}\n${catalog}${options}${terminator}\n',
 
 	spatialIndex: 'CREATE SPATIAL INDEX ${name} ON ${table} (${column})${using}\n${options}${terminator}\n',
 

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -17,7 +17,8 @@ module.exports = {
 		'CREATE${unique}${clustered}${columnstore} INDEX ${name}\n' +
 		'\tON ${table}${keys}${include}${expression}${relational_index_option}${terminator}\n',
 
-	fullTextIndex: 'CREATE FULLTEXT INDEX ON ${table}\nKEY INDEX ${indexName}\n${catalog}${options}${terminator}\n',
+	fullTextIndex:
+		'CREATE FULLTEXT INDEX ON ${table}${keys}\nKEY INDEX ${indexName}\n${catalog}${options}${terminator}\n',
 
 	spatialIndex: 'CREATE SPATIAL INDEX ${name} ON ${table} (${column})${using}\n${options}${terminator}\n',
 

--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -15,7 +15,7 @@ module.exports = {
 
 	index:
 		'CREATE${unique}${clustered}${columnstore} INDEX ${name}\n' +
-		'\tON ${table} ( ${keys} )${include}${expression}${relational_index_option}${terminator}\n',
+		'\tON ${table}${keys}${include}${expression}${relational_index_option}${terminator}\n',
 
 	fullTextIndex:
 		'CREATE FULLTEXT INDEX ON ${table} (\n\t${keys}\n)\nKEY INDEX ${indexName}\n${catalog}${options}${terminator}\n',

--- a/forward_engineering/helpers/indexHelper.js
+++ b/forward_engineering/helpers/indexHelper.js
@@ -61,7 +61,7 @@ module.exports = app => {
 	};
 
 	const createIndex = (terminator, tableName, index, isParentActivated = true) => {
-		if (_.isEmpty(index.keys)) {
+		if (_.isEmpty(index.keys) || !index.name) {
 			return '';
 		}
 
@@ -132,7 +132,7 @@ module.exports = app => {
 	};
 
 	const createFullTextIndex = (terminator, tableName, index, isParentActivated) => {
-		if (_.isEmpty(index.keys)) {
+		if (_.isEmpty(index.keys) || !index.keyIndex) {
 			return '';
 		}
 		const catalog = getFulltextCatalog(index);
@@ -206,7 +206,7 @@ module.exports = app => {
 	};
 
 	const createSpatialIndex = (terminator, tableName, index) => {
-		if (!index.column) {
+		if (!index.column || !index.name) {
 			return '';
 		}
 		const options = getSpatialOptions(index);

--- a/forward_engineering/helpers/indexHelper.js
+++ b/forward_engineering/helpers/indexHelper.js
@@ -61,7 +61,9 @@ module.exports = app => {
 	};
 
 	const createIndex = (terminator, tableName, index, isParentActivated = true) => {
-		if (_.isEmpty(index.keys) || !index.name) {
+		const isInvalidColumnStore = index.type !== 'columnstore' || (index.type === 'columnstore' && index.clustered);
+
+		if ((_.isEmpty(index.keys) && isInvalidColumnStore) || !index.name) {
 			return '';
 		}
 
@@ -81,16 +83,18 @@ module.exports = app => {
 			? commentIfDeactivated(dividedKeys.deactivatedItems.join(', '), { isActivated: false }, true)
 			: '';
 
+		const keys = isParentActivated
+			? dividedKeys.activatedItems.join(', ') + commentedKeys
+			: dividedKeys.activatedItems.join(', ') +
+				(dividedKeys.activatedItems.length ? ', ' : '') +
+				dividedKeys.deactivatedItems.join(', ');
+
 		return assignTemplates(templates.index, {
 			name: index.name,
 			unique: index.unique ? ' UNIQUE' : '',
 			clustered: index.clustered ? ' CLUSTERED' : '',
 			table: getTableName(tableName, index.schemaName),
-			keys: isParentActivated
-				? dividedKeys.activatedItems.join(', ') + commentedKeys
-				: dividedKeys.activatedItems.join(', ') +
-					(dividedKeys.activatedItems.length ? ', ' : '') +
-					dividedKeys.deactivatedItems.join(', '),
+			keys: dividedKeys.activatedItems.length || commentedKeys.length ? ` ( ${keys} )` : '',
 			columnstore: index.type === 'columnstore' ? ' COLUMNSTORE' : '',
 			relational_index_option: relationalIndexOption.length
 				? '\n\tWITH (\n\t\t' + relationalIndexOption.join(',\n\t\t') + '\n\t)'

--- a/forward_engineering/helpers/indexHelper.js
+++ b/forward_engineering/helpers/indexHelper.js
@@ -83,11 +83,14 @@ module.exports = app => {
 			? commentIfDeactivated(dividedKeys.deactivatedItems.join(', '), { isActivated: false }, true)
 			: '';
 
-		const keys = isParentActivated
-			? dividedKeys.activatedItems.join(', ') + commentedKeys
-			: dividedKeys.activatedItems.join(', ') +
-				(dividedKeys.activatedItems.length ? ', ' : '') +
-				dividedKeys.deactivatedItems.join(', ');
+		const activatedKeys = dividedKeys.activatedItems.join(', ');
+		const deactivatedKeys = dividedKeys.deactivatedItems.join(', ');
+
+		let keys = activatedKeys + commentedKeys;
+
+		if (!isParentActivated) {
+			keys = activatedKeys + (activatedKeys && deactivatedKeys ? ', ' : '') + deactivatedKeys;
+		}
 
 		return assignTemplates(templates.index, {
 			name: index.name,

--- a/forward_engineering/helpers/indexHelper.js
+++ b/forward_engineering/helpers/indexHelper.js
@@ -164,7 +164,7 @@ module.exports = app => {
 
 		return assignTemplates(templates.fullTextIndex, {
 			table: getTableName(tableName, index.schemaName),
-			keys: keys ? ` (\n\t${keys}\n)\n` : '',
+			keys: keys ? ` (\n\t${keys}\n)` : '',
 			indexName: index.keyIndex,
 			catalog: catalog ? `ON ${catalog}\n` : '',
 			options: options ? `WITH (\n\t${options}\n)` : '',

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -2,9 +2,9 @@
 * Copyright © 2016-2020 by IntegrIT S.A. dba Hackolade.  All rights reserved.
 *
 * The copyright to the computer software herein is the property of IntegrIT S.A.
-* The software may be used and/or copied only with the written permission of 
-* IntegrIT S.A. or in accordance with the terms and conditions stipulated in 
-* the agreement/contract under which the software has been supplied. 
+* The software may be used and/or copied only with the written permission of
+* IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+* the agreement/contract under which the software has been supplied.
 
 In order to define custom properties for any object's properties pane, you may copy/paste from the following,
 making sure that you maintain a proper JSON format.
@@ -69,8 +69,8 @@ making sure that you maintain a proper JSON format.
 				]
 			},
 // “groupInput” can have the following states - 0 items, 1 item, and many items.
-// “blockInput” has only 2 states - 0 items or 1 item. 
-// This gives us an easy way to represent it as an object and not as an array internally which is beneficial for processing 
+// “blockInput” has only 2 states - 0 items or 1 item.
+// This gives us an easy way to represent it as an object and not as an array internally which is beneficial for processing
 // and forward-engineering in particular.
 			{
 				"propertyName": "Block",
@@ -98,7 +98,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "keyList",
 				"propertyType": "fieldList",
 				"template": "orderedList"
-			}, 
+			},
 			{
 				"propertyName": "List with attribute",
 				"propertyKeyword": "keyListOrder",
@@ -666,7 +666,10 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
 						"propertyTooltip": "",
-						"propertyType": "text"
+						"propertyType": "text",
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Activated",
@@ -809,7 +812,10 @@ making sure that you maintain a proper JSON format.
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
 						"propertyTooltip": "",
-						"propertyType": "text"
+						"propertyType": "text",
+						"validation": {
+							"required": true
+						}
 					},
 					{
 						"propertyName": "Activated",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -927,15 +927,24 @@ making sure that you maintain a proper JSON format.
 						"template": "orderedList",
 						"attributeList": ["ascending", "descending"],
 						"dependency": {
-							"type": "and",
+							"type": "or",
 							"values": [
 								{
 									"key": "indxType",
-									"value": "Columnstore"
+									"value": "FullText"
 								},
 								{
-									"key": "clusteredIndx",
-									"value": true
+									"type": "and",
+									"values": [
+										{
+											"key": "indxType",
+											"value": "Columnstore"
+										},
+										{
+											"key": "clusteredIndx",
+											"value": true
+										}
+									]
 								}
 							]
 						}
@@ -1401,17 +1410,6 @@ making sure that you maintain a proper JSON format.
 									"value": "Spatial"
 								}
 							]
-						}
-					},
-					{
-						"propertyName": "Keys",
-						"propertyKeyword": "indxKey",
-						"propertyType": "fieldList",
-						"template": "orderedList",
-						"attributeList": [],
-						"dependency": {
-							"key": "indxType",
-							"value": "FullText"
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -886,8 +886,13 @@ making sure that you maintain a proper JSON format.
 									"value": "Columnstore"
 								},
 								{
-									"key": "clusteredIndx",
-									"value": false
+									"type": "not",
+									"values": [
+										{
+											"key": "clusteredIndx",
+											"value": true
+										}
+									]
 								}
 							]
 						},
@@ -1388,10 +1393,6 @@ making sure that you maintain a proper JSON format.
 						"dependency": {
 							"key": "indxType",
 							"value": "FullText"
-						},
-						"validation": {
-							"required": true,
-							"minLength": 1
 						}
 					},
 					{
@@ -1423,11 +1424,13 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "Key index",
 						"propertyKeyword": "indxFullTextKeyIndex",
-						"requiredProperty": true,
 						"propertyType": "text",
 						"dependency": {
 							"key": "indxType",
 							"value": "FullText"
+						},
+						"validation": {
+							"required": true
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -815,6 +815,25 @@ making sure that you maintain a proper JSON format.
 						"propertyType": "text",
 						"validation": {
 							"required": true
+						},
+						"dependency": {
+							"type": "not",
+							"values": [
+								{
+									"key": "indxType",
+									"value": "FullText"
+								}
+							]
+						}
+					},
+					{
+						"propertyName": "Name",
+						"propertyKeyword": "indxName",
+						"propertyTooltip": "",
+						"propertyType": "text",
+						"dependency": {
+							"key": "indxType",
+							"value": "FullText"
 						}
 					},
 					{

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -863,16 +863,55 @@ making sure that you maintain a proper JSON format.
 						"propertyType": "fieldList",
 						"template": "orderedList",
 						"attributeList": ["ascending", "descending"],
+						"validation": {
+							"required": true,
+							"minLength": 1
+						},
 						"dependency": {
-							"type": "or",
+							"key": "indxType",
+							"value": "Index"
+						}
+					},
+					{
+						"propertyName": "Keys",
+						"propertyKeyword": "indxKey",
+						"propertyType": "fieldList",
+						"template": "orderedList",
+						"attributeList": ["ascending", "descending"],
+						"dependency": {
+							"type": "and",
 							"values": [
 								{
 									"key": "indxType",
-									"value": "Index"
+									"value": "Columnstore"
 								},
+								{
+									"key": "clusteredIndx",
+									"value": false
+								}
+							]
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
+						}
+					},
+					{
+						"propertyName": "Keys",
+						"propertyKeyword": "indxKey",
+						"propertyType": "fieldList",
+						"template": "orderedList",
+						"attributeList": ["ascending", "descending"],
+						"dependency": {
+							"type": "and",
+							"values": [
 								{
 									"key": "indxType",
 									"value": "Columnstore"
+								},
+								{
+									"key": "clusteredIndx",
+									"value": true
 								}
 							]
 						}
@@ -889,6 +928,10 @@ making sure that you maintain a proper JSON format.
 						},
 						"templateOptions": {
 							"maxFields": 1
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
 						}
 					},
 					{
@@ -1345,6 +1388,10 @@ making sure that you maintain a proper JSON format.
 						"dependency": {
 							"key": "indxType",
 							"value": "FullText"
+						},
+						"validation": {
+							"required": true,
+							"minLength": 1
 						}
 					},
 					{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in the "Create Index" script
- index name is required in all cases except when the index is a `fulltext`
- сolumns are required in all cases except when the index is a `clustered columnstore` or `fulltext`.