### PR TITLE
HCK-9173: comment out inactive schema statement in script

### DIFF
--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -45,7 +45,7 @@ module.exports = (baseProvider, options, app) => {
 	const terminator = getTerminator(options);
 
 	return {
-		createSchema({ schemaName, databaseName, ifNotExist, comment, isActivated }) {
+		createSchema({ schemaName, databaseName, ifNotExist, comment, isActivated = true }) {
 			const schemaTerminator = ifNotExist ? ';' : terminator;
 
 			const schemaComment = comment

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -45,7 +45,7 @@ module.exports = (baseProvider, options, app) => {
 	const terminator = getTerminator(options);
 
 	return {
-		createSchema({ schemaName, databaseName, ifNotExist, comment }) {
+		createSchema({ schemaName, databaseName, ifNotExist, comment, isActivated }) {
 			const schemaTerminator = ifNotExist ? ';' : terminator;
 
 			const schemaComment = comment
@@ -56,11 +56,14 @@ module.exports = (baseProvider, options, app) => {
 					})
 				: '';
 
-			let schemaStatement = assignTemplates(templates.createSchema, {
-				name: schemaName,
-				terminator: schemaTerminator,
-				comment: schemaComment ? `\n\n${schemaComment}` : '',
-			});
+			let schemaStatement = commentIfDeactivated(
+				assignTemplates(templates.createSchema, {
+					name: schemaName,
+					terminator: schemaTerminator,
+					comment: schemaComment ? `\n\n${schemaComment}` : '',
+				}),
+				{ isActivated },
+			);
 
 			if (!databaseName) {
 				return ifNotExist
@@ -500,6 +503,7 @@ module.exports = (baseProvider, options, app) => {
 				databaseName: containerData.databaseName,
 				ifNotExist: containerData.ifNotExist,
 				comment: containerData.role?.description ?? containerData.description,
+				isActivated: containerData.isActivated,
 			};
 		},
 

--- a/forward_engineering/helpers/commentIfDeactivated.js
+++ b/forward_engineering/helpers/commentIfDeactivated.js
@@ -2,7 +2,7 @@ const BEFORE_DEACTIVATED_STATEMENT = '-- ';
 const REG_FOR_MULTYLINE_COMMENT = /(\n\/\*\n[\s\S]*?\n\s\*\/\n)|((\n\/\*\n[\s\S]*?\n\s\*\/)$)/gi;
 
 const commentIfDeactivated = (statement, data, isPartOfLine) => {
-	if (data?.hasOwnProperty('isActivated') && !data.isActivated) {
+	if (data.isActivated === false) {
 		if (isPartOfLine) {
 			return '/* ' + statement + ' */';
 		} else if (statement.includes('\n')) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9173" title="HCK-9173" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9173</a>  Statements are still incorrectly present in DDL/Script tab after 'isActivated' is disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...