### PR TITLE
HCK-9893: Add missing synonym to MSSQLServer target

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2,9 +2,9 @@
 * Copyright © 2016-2017 by IntegrIT S.A. dba Hackolade.  All rights reserved.
 *
 * The copyright to the computer software herein is the property of IntegrIT S.A.
-* The software may be used and/or copied only with the written permission of 
-* IntegrIT S.A. or in accordance with the terms and conditions stipulated in 
-* the agreement/contract under which the software has been supplied. 
+* The software may be used and/or copied only with the written permission of
+* IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+* the agreement/contract under which the software has been supplied.
 
 
 In order to define custom properties for any object's properties pane, you may copy/paste from the following,
@@ -71,8 +71,8 @@ making sure that you maintain a proper JSON format.
 				]
 			},
 // “groupInput” can have the following states - 0 items, 1 item, and many items.
-// “blockInput” has only 2 states - 0 items or 1 item. 
-// This gives us an easy way to represent it as an object and not as an array internally which is beneficial for processing 
+// “blockInput” has only 2 states - 0 items or 1 item.
+// This gives us an easy way to represent it as an object and not as an array internally which is beneficial for processing
 // and forward-engineering in particular.
 			{
 				"propertyName": "Block",
@@ -100,7 +100,7 @@ making sure that you maintain a proper JSON format.
 				"propertyKeyword": "keyList",
 				"propertyType": "fieldList",
 				"template": "orderedList"
-			}, 
+			},
 			{
 				"propertyName": "List with attribute",
 				"propertyKeyword": "keyListOrder",
@@ -978,6 +978,30 @@ making sure that you maintain a proper JSON format.
 				"valueType": "string"
 			},
 			{
+				"propertyName": "Synonym",
+				"propertyKeyword": "synonym",
+				"propertyType": "select",
+				"options": ["", "dec"],
+				"data": "options",
+				"valueType": "string",
+				"dependency": {
+					"key": "mode",
+					"value": "decimal"
+				}
+			},
+			{
+				"propertyName": "Synonym",
+				"propertyKeyword": "synonym",
+				"propertyType": "select",
+				"options": ["", "double precision"],
+				"data": "options",
+				"valueType": "string",
+				"dependency": {
+					"key": "mode",
+					"value": "float"
+				}
+			},
+			{
 				"propertyName": "Precision",
 				"propertyKeyword": "precision",
 				"propertyType": "numeric",
@@ -1692,6 +1716,18 @@ making sure that you maintain a proper JSON format.
 				"options": ["binary", "image", "varbinary"],
 				"data": "options",
 				"valueType": "string"
+			},
+			{
+				"propertyName": "Synonym",
+				"propertyKeyword": "synonym",
+				"propertyType": "select",
+				"options": ["", "binary varying"],
+				"data": "options",
+				"valueType": "string",
+				"dependency": {
+					"key": "mode",
+					"value": "varbinary"
+				}
 			},
 			{
 				"propertyName": "Has max length",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9893" title="HCK-9893" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9893</a>  Unrecognized data type - Case 1 = Add missing synonym in target MSSQLServer
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
