### PR TITLE
HCK-12142: Extend the support of default value constraint

### DIFF
--- a/forward_engineering/configs/templates.js
+++ b/forward_engineering/configs/templates.js
@@ -11,7 +11,7 @@ module.exports = {
 		')${options}${terminator}\n${comment}${columnComments}',
 
 	columnDefinition:
-		'[${name}] ${type}${primary_key}${temporalTableTime}${sparse}${maskedWithFunction}${identity}${default}${collation}${not_null}${encryptedWith}',
+		'[${name}] ${type}${primary_key}${temporalTableTime}${sparse}${maskedWithFunction}${identity}${collation}${not_null}${default}${encryptedWith}',
 	computedColumnDefinition: '[${name}] AS ${expression}${persisted}${key}${not_null}',
 
 	index:

--- a/forward_engineering/ddlProvider.js
+++ b/forward_engineering/ddlProvider.js
@@ -25,7 +25,6 @@ module.exports = (baseProvider, options, app) => {
 		getTableName,
 		getTableOptions,
 		hasType,
-		getDefaultConstraints,
 		foreignKeysToString,
 		checkIndexActivated,
 		getDefaultValue,
@@ -99,6 +98,10 @@ module.exports = (baseProvider, options, app) => {
 			return databaseStatement + '\n\n' + useStatement + '\n\n' + schemaStatement;
 		},
 
+		createDefaultConstraint(data, tableName, terminator = ';') {
+			return createDefaultConstraint(templates, terminator)(data, tableName);
+		},
+
 		createTable(
 			{
 				name,
@@ -161,20 +164,15 @@ module.exports = (baseProvider, options, app) => {
 				comment: tableComment ? `\n${tableComment}` : '',
 				columnComments: columnComments ? `${tableAndColumnCommentsSeparator}${columnComments}\n` : '',
 			});
-			const defaultConstraintsStatements = defaultConstraints
-				.map(data => createDefaultConstraint(templates, tableTerminator)(data, tableName))
-				.join('\n');
-
-			const fullTableStatement = [tableStatement, defaultConstraintsStatements].filter(Boolean).join('\n\n');
 
 			return ifNotExist
 				? wrapIfNotExistTable({
-						tableStatement: fullTableStatement,
+						tableStatement,
 						templates,
 						tableName: getTableName(name, schemaData.schemaName, false),
 						terminator,
 					})
-				: fullTableStatement;
+				: tableStatement;
 		},
 
 		createComputedColumn({ name, computedExpression, persisted, primaryKey, unique, notNull }) {
@@ -201,11 +199,7 @@ module.exports = (baseProvider, options, app) => {
 			const primaryKey = columnDefinition.primaryKey
 				? ' ' + createPKConstraint(templates, terminator, true)(columnDefinition.primaryKeyOptions).statement
 				: '';
-			const defaultValue = getDefaultValue(
-				columnDefinition.default,
-				columnDefinition.defaultConstraint?.name,
-				type,
-			);
+			const defaultValue = getDefaultValue(columnDefinition.defaultConstraint, type);
 			const sparse = columnDefinition.sparse ? ' SPARSE' : '';
 			const maskedWithFunction = columnDefinition.maskedWithFunction
 				? ` MASKED WITH (FUNCTION='${columnDefinition.maskedWithFunction}')`
@@ -464,7 +458,6 @@ module.exports = (baseProvider, options, app) => {
 				_.get(parentJsonSchema, 'periodForSystemTime[0].startTime[0].type', '') === 'hidden';
 
 			return Object.assign({}, columnDefinition, {
-				default: jsonSchema.defaultConstraintName ? '' : columnDefinition.default,
 				defaultConstraint: {
 					name: jsonSchema.defaultConstraintName,
 					value: columnDefinition.default,
@@ -547,7 +540,6 @@ module.exports = (baseProvider, options, app) => {
 			return Object.assign({}, tableData, {
 				foreignKeyConstraints: tableData.foreignKeyConstraints || [],
 				keyConstraints: keyHelper.getTableKeyConstraints({ jsonSchema }),
-				defaultConstraints: getDefaultConstraints(tableData.columnDefinitions),
 				ifNotExist: jsonSchema.ifNotExist,
 				comment: jsonSchema.description,
 				columnDefinitions: tableData.columnDefinitions,

--- a/forward_engineering/helpers/alterScriptHelpers/alterEntityHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/alterEntityHelper.js
@@ -9,6 +9,7 @@ module.exports = (app, options) => {
 	const { generateIdToNameHashTable, generateIdToActivatedHashTable } = app.require('@hackolade/ddl-fe-utils');
 	const { setIndexKeys, modifyGroupItems } = require('./common')(app);
 	const { getRenameColumnScriptsDto } = require('./columnHelpers/renameColumnHelpers')(app, ddlProvider);
+	const { getDefaultValueChangeDto } = require('./columnHelpers/defaultValueColumnHelper')(app, ddlProvider);
 	const { getChangedComputedColumnsScriptsDto } = require('./columnHelpers/alterComputedColumnHelpr')(
 		app,
 		ddlProvider,
@@ -199,6 +200,7 @@ module.exports = (app, options) => {
 			collectionSchema,
 			schemaName,
 		);
+		const modifiedDefaultValues = getDefaultValueChangeDto(collection, fullName);
 		const changedComputedScriptsDtos = getChangedComputedColumnsScriptsDto({
 			collection,
 			fullName,
@@ -210,6 +212,7 @@ module.exports = (app, options) => {
 			...renameColumnScriptsDtos,
 			...changeTypeScriptsDtos,
 			...modifyNotNullScriptDtos,
+			...modifiedDefaultValues,
 			...changedComputedScriptsDtos,
 		].filter(Boolean);
 	};

--- a/forward_engineering/helpers/alterScriptHelpers/columnHelpers/defaultValueColumnHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/columnHelpers/defaultValueColumnHelper.js
@@ -7,7 +7,7 @@ module.exports = (app, ddlProvider) => {
 
 		const getDefaultConstraintName = columnName => sanitizeConstraintName(`DF_${fullName}_${columnName}`);
 
-		Object.entries(collection.properties).forEach(([columnName, collectionSchema]) => {
+		Object.entries(collection?.properties ?? []).forEach(([columnName, collectionSchema]) => {
 			const newDefaultValue = collectionSchema.default;
 			const newConstraintName = collectionSchema.defaultConstraintName;
 			const oldDefaultValue = collection.role.properties[columnName]?.default;

--- a/forward_engineering/helpers/alterScriptHelpers/columnHelpers/defaultValueColumnHelper.js
+++ b/forward_engineering/helpers/alterScriptHelpers/columnHelpers/defaultValueColumnHelper.js
@@ -1,0 +1,96 @@
+module.exports = (app, ddlProvider) => {
+	const { AlterScriptDto } = require('../types/AlterScriptDto');
+	const { sanitizeConstraintName } = require('../../../helpers/general')(app);
+
+	const getDefaultValueChangeDto = (collection, fullName) => {
+		const scripts = [];
+
+		const getDefaultConstraintName = columnName => sanitizeConstraintName(`DF_${fullName}_${columnName}`);
+
+		Object.entries(collection.properties).forEach(([columnName, collectionSchema]) => {
+			const newDefaultValue = collectionSchema.default;
+			const newConstraintName = collectionSchema.defaultConstraintName;
+			const oldDefaultValue = collection.role.properties[columnName]?.default;
+			const oldConstraintName = collection.role.properties[columnName]?.defaultConstraintName;
+
+			const defaultValueWasRemoved = !!oldDefaultValue && !newDefaultValue;
+			const defaultValueWasAdded = !oldDefaultValue && !!newDefaultValue;
+			const defaultValueWasChanged =
+				!!oldDefaultValue && !!newDefaultValue && oldDefaultValue !== newDefaultValue;
+			const constraintNameChanged =
+				!!oldDefaultValue &&
+				!!newDefaultValue &&
+				oldDefaultValue === newDefaultValue &&
+				!!oldConstraintName &&
+				!!newConstraintName &&
+				oldConstraintName !== newConstraintName;
+
+			switch (true) {
+				case defaultValueWasRemoved: {
+					if (oldConstraintName) {
+						const dropScript = ddlProvider.dropConstraint(fullName, oldConstraintName);
+						scripts.push(AlterScriptDto.getInstance([dropScript], true, true));
+					}
+					break;
+				}
+				case defaultValueWasAdded: {
+					const constraintName = newConstraintName || getDefaultConstraintName(columnName);
+
+					const createScript = ddlProvider.createDefaultConstraint(
+						{
+							constraintName,
+							columnName,
+							value: newDefaultValue,
+						},
+						fullName,
+					);
+					scripts.push(AlterScriptDto.getInstance([createScript], true, false));
+					break;
+				}
+				case defaultValueWasChanged: {
+					if (oldConstraintName) {
+						const dropScript = ddlProvider.dropConstraint(fullName, oldConstraintName);
+						scripts.push(AlterScriptDto.getInstance([dropScript], true, true));
+					}
+					const constraintName = newConstraintName || getDefaultConstraintName(columnName);
+
+					const createScript = ddlProvider.createDefaultConstraint(
+						{
+							constraintName,
+							columnName,
+							value: newDefaultValue,
+						},
+						fullName,
+					);
+					scripts.push(AlterScriptDto.getInstance([createScript], true, false));
+					break;
+				}
+				case constraintNameChanged: {
+					const dropScript = ddlProvider.dropConstraint(fullName, oldConstraintName);
+
+					const createScript = ddlProvider.createDefaultConstraint(
+						{
+							constraintName: newConstraintName,
+							columnName,
+							value: newDefaultValue,
+						},
+						fullName,
+					);
+					scripts.push(
+						AlterScriptDto.getInstance([dropScript], true, true),
+						AlterScriptDto.getInstance([createScript], true, false),
+					);
+					break;
+				}
+				default:
+					break;
+			}
+		});
+
+		return scripts;
+	};
+
+	return {
+		getDefaultValueChangeDto,
+	};
+};

--- a/forward_engineering/helpers/general.js
+++ b/forward_engineering/helpers/general.js
@@ -17,14 +17,22 @@ module.exports = app => {
 		return withBrackets(tableName);
 	};
 
-	const getDefaultValue = (defaultValue, defaultConstraintName, type) => {
-		if (_.isUndefined(defaultValue)) {
+	const getDefaultValue = (defaultConstraint, type) => {
+		if (_.isUndefined(defaultConstraint.value)) {
 			return '';
 		}
-		if (!_.isUndefined(defaultConstraintName)) {
-			return '';
+
+		const value = decorateDefault(type, defaultConstraint.value);
+
+		if (!_.isUndefined(defaultConstraint.name)) {
+			return ` CONSTRAINT ${defaultConstraint.name} DEFAULT ${value}`;
 		}
-		return ` DEFAULT ${decorateDefault(type, defaultValue)}`;
+
+		return ` DEFAULT ${value}`;
+	};
+
+	const sanitizeConstraintName = str => {
+		return str ? str.replace(/\[|\]/g, '').replace(/\./g, '_') : str;
 	};
 
 	const getKeyWithAlias = key => {
@@ -189,22 +197,6 @@ module.exports = app => {
 		}, {});
 	};
 
-	const getDefaultConstraints = columnDefinitions => {
-		if (!Array.isArray(columnDefinitions)) {
-			return [];
-		}
-
-		return columnDefinitions
-			.filter(
-				column => _.get(column, 'defaultConstraint.name') && !_.isNil(_.get(column, 'defaultConstraint.value')),
-			)
-			.map(column => ({
-				columnName: column.name,
-				constraintName: column.defaultConstraint.name,
-				value: decorateDefault(column.type, column.defaultConstraint.value),
-			}));
-	};
-
 	const foreignKeysToString = keys => {
 		if (Array.isArray(keys)) {
 			const activatedKeys = keys
@@ -266,10 +258,10 @@ module.exports = app => {
 		getTableOptions,
 		hasType,
 		getViewData,
-		getDefaultConstraints,
 		foreignKeysToString,
 		additionalPropertiesForForeignKey,
 		trimBraces,
+		sanitizeConstraintName,
 		checkIndexActivated,
 		foreignActiveKeysToString,
 		getDefaultValue,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12142" title="HCK-12142" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12142</a>  [SQL Server][Script generation options] Column default values are missing for In separate statement strategy
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Extended logic of the alter to print the changes default values/constraints;
- Use inline syntax for named constraints according to the [doc](https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-default-values-for-columns?view=sql-server-ver17). It's also essential for script generation options.

## Technical details

- Improved alter script;
- Change processing of named default constraints;