### PR TITLE
HCK-12232: fix type displayed near json column

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -5128,7 +5128,12 @@ making sure that you maintain a proper JSON format.
 			"name",
 			"code",
 			"schemaId",
-			"type",
+			{
+				"propertyKeyword": "type",
+				"typeDecorator": {
+					"useAsTypeName": true
+				}
+			},
 			{
 				"propertyName": "JSON Type",
 				"propertyKeyword": "physicalType",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12232" title="HCK-12232" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12232</a>  Type display in ERD should be "json" (the Type) and not "object" or "array" (JSON Types)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Display proper column type of `json` columns
<img width="220" height="65" alt="image" src="https://github.com/user-attachments/assets/e2e3522b-7fe3-4c17-bdd5-723eeb58b0ff" />
