### PR TITLE
HCK-12274: fix conversion of json data type into json type in Polyglot

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -53,7 +53,11 @@
 						}
 					}
 				}
-			]
+			],
+			{
+				"from": { "type": "json" },
+				"to": { "mode": "json" }
+			}
 		]
 	},
 	"add": {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12274" title="HCK-12274" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12274</a>  [MS SQL Server 2025][Polyglot] Invalid convert/derive to/from polyglot of JSON datatypes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Ensure that type `json` is converted to type `json` in Polyglot target.