### PR TITLE
HCK-12260: MS SQL Server - adapter when DB version is downgraded from 2025

### DIFF
--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -72,7 +72,21 @@ making sure that you maintain a proper JSON format.
 				"propertyTooltip": "DB version",
 				"propertyType": "select",
 				"options": ["2008", "2012", "2014", "2016", "2017", "2019", "2022", "2025"],
-				"disabledOption": false
+				"disabledOption": false,
+				"adapters": [
+					{
+						"dependency": {
+							"type": "not",
+							"values": [
+								{
+									"key": "dbVersion",
+									"value": "2025"
+								}
+							]
+						},
+						"adapter": "adaptJsonTypesToVarchar"
+					}
+				]
 			},
 			{
 				"propertyName": "Comments",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12260" title="HCK-12260" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12260</a>  [SQL Server 2025] Add adaptor on version switch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Added logic to trigger adapter when downgrading version from `2025`. More details in `Studio` PR: https://github.com/hackolade/studio/pull/3731

...