### PR TITLE
HCK-12377: Do not format comments

### DIFF
--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -166,15 +166,16 @@ module.exports = _ => {
 		return name.replace(/'/g, "''");
 	};
 
-	const skipSqlCommentsPattern = /^\s*(EXEC(UTE)?\b|.*\bMS_DESCRIPTION\b)/i;
+	const skipSqlCommentsPattern = /^\s*(EXEC\b|.*\bMS_DESCRIPTION\b)/i;
 
 	const buildScript = statements => {
-		const formattedScripts = statements.filter(Boolean).map(script => {
-			if (skipSqlCommentsPattern.test(script)) {
-				return script;
-			}
-			return sqlFormatter.format(script, { indent: '    ' }).replace(/\{ \{ (.+?) } }/g, '{{$1}}');
-		});
+		const formattedScripts = statements
+			.filter(Boolean)
+			.map(script =>
+				skipSqlCommentsPattern.test(script)
+					? script
+					: sqlFormatter.format(script, { indent: '    ' }).replace(/\{ \{ (.+?) } }/g, '{{$1}}'),
+			);
 
 		return formattedScripts.join('\n\n') + '\n\n';
 	};

--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -166,10 +166,15 @@ module.exports = _ => {
 		return name.replace(/'/g, "''");
 	};
 
+	const skipSqlCommentsPattern = /^\s*(EXEC(UTE)?\b|.*\bMS_DESCRIPTION\b)/i;
+
 	const buildScript = statements => {
-		const formattedScripts = statements
-			.filter(Boolean)
-			.map(script => sqlFormatter.format(script, { indent: '    ' }).replace(/\{ \{ (.+?) } }/g, '{{$1}}'));
+		const formattedScripts = statements.filter(Boolean).map(script => {
+			if (skipSqlCommentsPattern.test(script)) {
+				return script;
+			}
+			return sqlFormatter.format(script, { indent: '    ' }).replace(/\{ \{ (.+?) } }/g, '{{$1}}');
+		});
 
 		return formattedScripts.join('\n\n') + '\n\n';
 	};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12377" title="HCK-12377" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12377</a>  Do not format comments
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Context

Previously, before Script generation options activation, comments were not formatted when generating DDL CREATE statements, but they were formatted for ALTER statements. Later, the logic was combined, and formatting was applied in both cases. However, this resulted in incorrect formatting for some comments (probably a bug of sql-formatter).

This PR will ignore the formatting of comments
