### PR TITLE
Change labels for Microsoft Entra authentication methods

### DIFF
--- a/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
+++ b/reverse_engineering/connection_settings_modal/connectionSettingsModalConfig.json
@@ -126,12 +126,12 @@
 						"label": "Windows"
 					},
 					{
-						"value": "Azure Active Directory (Username / Password)",
-						"label": "Azure Active Directory (Username / Password)"
+						"value": "Azure Active Directory (MFA)",
+						"label": "Microsoft Entra ID via authorization code flow (PCKE)"
 					},
 					{
-						"value": "Azure Active Directory (MFA)",
-						"label": "Azure Entra ID (MFA)"
+						"value": "Azure Active Directory (Username / Password)",
+						"label": "Microsoft Entra ID via username/password (ROPC - legacy)"
 					}
 				]
 			},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13057" title="HCK-13057" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13057</a>  Rename authentication method (remove "MFA")
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Microsoft rebranded its authentication method from Active Directory to Entra. The two options were renamed to align with the new name and to clarify their distinctions.

The recommended method (authentication flow) has been put first (as recommended over the username/password)