### PR TITLE
HCK-13422: fix the conversion of type uniqueidentifier to polyglot and back

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -119,7 +119,11 @@
 						}
 					}
 				}
-			]
+			],
+			{
+				"from": { "childType": "uuid" },
+				"to": { "mode": "uniqueidentifier" }
+			}
 		]
 	}
 }

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -57,6 +57,10 @@
 			{
 				"from": { "type": "json" },
 				"to": { "mode": "json" }
+			},
+			{
+				"from": { "childType": "uniqueidentifier" },
+				"to": { "mode": "uuid" }
 			}
 		]
 	},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13422" title="HCK-13422" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-13422</a>  [SQL Server][Convert to Polyglot] Datatypes incorrectly changed after conversion to Polyglot
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Type `uniqueidentifier` should be converted to `uuid` in Polyglot
Type `uuid` in Polyglot should be converted to `uniqueidentifier` in SQL Server