### PR TITLE
HCK-14706: properly escape new lines

### DIFF
--- a/forward_engineering/utils/general.js
+++ b/forward_engineering/utils/general.js
@@ -162,8 +162,8 @@ const wrapInBracketsIfNecessary = name => {
 	return name.replace(/^(?!\().*?(?<!\))$/, '($&)');
 };
 
-const escapeSpecialCharacters = (name = '') => {
-	return name.replace(/'/g, "''");
+const escapeSpecialCharacters = (str = '') => {
+	return str.replaceAll("'", "''").replaceAll('\n', '\r\n');
 };
 
 const skipSqlCommentsPattern = /^\s*(EXEC\b|.*\bMS_DESCRIPTION\b)/i;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14706" title="HCK-14706" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14706</a>  Multiline description failed to be applied
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

* convert \n into CRLF